### PR TITLE
lazy public key init

### DIFF
--- a/eddsa.iml
+++ b/eddsa.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -15,4 +15,3 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>
 </module>
-

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.i2p.crypto</groupId>
   <artifactId>eddsa</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <name>EdDSA-Java</name>
   <packaging>bundle</packaging>
   <description>Implementation of EdDSA in Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
         <version>3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
           <charset>UTF-8</charset>
           <docencoding>UTF-8</docencoding>
           <encoding>UTF-8</encoding>
+          <additionalparam>--allow-script-in-comments</additionalparam>
           <header>&lt;script type='text/x-mathjax-config'&gt;
   MathJax.Hub.Config({
     tex2jax: {

--- a/src/net/i2p/crypto/eddsa/EdDSAPrivateKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPrivateKey.java
@@ -82,10 +82,10 @@ public class EdDSAPrivateKey implements EdDSAKey, PrivateKey {
      * This implements the following specs:
      *<ul><li>
      * General encoding: https://tools.ietf.org/html/draft-ietf-curdle-pkix-04
-     *</li></li>
+     *</li><li>
      * Key encoding: https://tools.ietf.org/html/rfc8032
      *</li></ul>
-     *</p><p>
+     *<p>
      * This encodes the seed. It will return null if constructed from
      * a spec which was directly constructed from H, in which case seed is null.
      *</p><p>

--- a/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
@@ -249,9 +249,11 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
     }
 
     public GroupElement getNegativeA() {
-        if (Aneg == null){
-            Aneg = A.negate();
-            Aneg.precompute(false);
+        synchronized (this) {
+            if (Aneg == null) {
+                Aneg = A.negate();
+                Aneg.precompute(false);
+            }
         }
         return Aneg;
     }

--- a/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
@@ -43,6 +43,7 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
     private final GroupElement Aneg;
     private final byte[] Abyte;
     private final EdDSAParameterSpec edDsaSpec;
+    private boolean aNegPrecomputed = false;
 
     // OID 1.3.101.xxx
     private static final int OID_OLD = 100;
@@ -78,10 +79,10 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
      * This implements the following specs:
      *<ul><li>
      * General encoding: https://tools.ietf.org/html/draft-ietf-curdle-pkix-04
-     *</li></li>
+     *</li><li>
      * Key encoding: https://tools.ietf.org/html/rfc8032
      *</li></ul>
-     *</p><p>
+     *<p>
      * For keys in older formats, decoding and then re-encoding is sufficient to
      * migrate them to the canonical encoding.
      *</p>
@@ -250,6 +251,10 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
     }
 
     public GroupElement getNegativeA() {
+        if (!this.aNegPrecomputed){
+            Aneg.precompute(false);
+            this.aNegPrecomputed = true;
+        }
         return Aneg;
     }
 

--- a/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
+++ b/src/net/i2p/crypto/eddsa/EdDSAPublicKey.java
@@ -40,10 +40,9 @@ import net.i2p.crypto.eddsa.spec.EdDSAPublicKeySpec;
 public class EdDSAPublicKey implements EdDSAKey, PublicKey {
     private static final long serialVersionUID = 9837459837498475L;
     private final GroupElement A;
-    private final GroupElement Aneg;
+    private GroupElement Aneg = null;
     private final byte[] Abyte;
     private final EdDSAParameterSpec edDsaSpec;
-    private boolean aNegPrecomputed = false;
 
     // OID 1.3.101.xxx
     private static final int OID_OLD = 100;
@@ -53,7 +52,6 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
 
     public EdDSAPublicKey(EdDSAPublicKeySpec spec) {
         this.A = spec.getA();
-        this.Aneg = spec.getNegativeA();
         this.Abyte = this.A.toByteArray();
         this.edDsaSpec = spec.getParams();
     }
@@ -251,9 +249,9 @@ public class EdDSAPublicKey implements EdDSAKey, PublicKey {
     }
 
     public GroupElement getNegativeA() {
-        if (!this.aNegPrecomputed){
+        if (Aneg == null){
+            Aneg = A.negate();
             Aneg.precompute(false);
-            this.aNegPrecomputed = true;
         }
         return Aneg;
     }

--- a/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
+++ b/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
@@ -34,7 +34,6 @@ public class EdDSAPublicKeySpec implements KeySpec {
             throw new IllegalArgumentException("public-key length is wrong");
 
         this.A = new GroupElement(spec.getCurve(), pk);
-        // Precompute -A for use in verification.
         this.Aneg = A.negate();
         this.spec = spec;
     }

--- a/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
+++ b/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
@@ -21,7 +21,6 @@ import net.i2p.crypto.eddsa.math.GroupElement;
  */
 public class EdDSAPublicKeySpec implements KeySpec {
     private final GroupElement A;
-    private final GroupElement Aneg;
     private final EdDSAParameterSpec spec;
 
     /**
@@ -34,22 +33,16 @@ public class EdDSAPublicKeySpec implements KeySpec {
             throw new IllegalArgumentException("public-key length is wrong");
 
         this.A = new GroupElement(spec.getCurve(), pk);
-        this.Aneg = A.negate();
         this.spec = spec;
     }
 
     public EdDSAPublicKeySpec(GroupElement A, EdDSAParameterSpec spec) {
         this.A = A;
-        this.Aneg = A.negate();
         this.spec = spec;
     }
 
     public GroupElement getA() {
         return A;
-    }
-
-    public GroupElement getNegativeA() {
-        return Aneg;
     }
 
     public EdDSAParameterSpec getParams() {

--- a/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
+++ b/src/net/i2p/crypto/eddsa/spec/EdDSAPublicKeySpec.java
@@ -36,14 +36,12 @@ public class EdDSAPublicKeySpec implements KeySpec {
         this.A = new GroupElement(spec.getCurve(), pk);
         // Precompute -A for use in verification.
         this.Aneg = A.negate();
-        Aneg.precompute(false);
         this.spec = spec;
     }
 
     public EdDSAPublicKeySpec(GroupElement A, EdDSAParameterSpec spec) {
         this.A = A;
         this.Aneg = A.negate();
-        Aneg.precompute(false);
         this.spec = spec;
     }
 


### PR DESCRIPTION
This avoids precomputing negative A (in itself an optimisation for efficient verification) in cases where we never use a public key for verification in a process that reads it in or creates in (quite common for e.g. anonymised key pairs).